### PR TITLE
Merge dependabot.yml Fix[Important]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
     milestone: 4
-    asignees:
+    assignees:
       - "Morgan-Phoenix"
     labels:
       - "dependencies"


### PR DESCRIPTION
This fix is important becuase even though it was just a typo It breaks dependabot causig CI to fail.