### PR TITLE
Added function that converts a roman numeral to its integer equivalent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,13 @@ archive/
 # Batch files for automation #
 ##############################
 automation/
+
+# Virtual environments #
+##############################
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/py_everything/roman.py
+++ b/py_everything/roman.py
@@ -1,12 +1,12 @@
-from typing import Union, List, Dict
+from typing import Dict
 
 
-def convertRoman(roman: str) -> str:
+def convertRoman(roman: str) -> int:
     """Changes given roman numeral to the integer equivalent"""
 
     roman = roman.upper()  # change entered value to upper case
 
-    rom_val: dict[str, int] = {
+    rom_val: Dict[str, int] = {
         "I": 1,
         "V": 5,
         "X": 10,

--- a/py_everything/roman.py
+++ b/py_everything/roman.py
@@ -1,0 +1,27 @@
+from typing import Union, List, Dict
+
+
+def convertRoman(roman: str) -> str:
+    """Changes given roman numeral to the integer equivalent"""
+
+    roman = roman.upper()  # change entered value to upper case
+
+    rom_val: dict[str, int] = {
+        "I": 1,
+        "V": 5,
+        "X": 10,
+        "L": 50,
+        "C": 100,
+        "D": 500,
+        "M": 1000,
+    }
+
+    int_val: int = 0
+
+    for i in range(len(roman)):
+        if i > 0 and rom_val[roman[i]] > rom_val[roman[i - 1]]:
+            int_val += rom_val[roman[i]] - 2 * rom_val[roman[i - 1]]
+        else:
+            int_val += rom_val[roman[i]]
+
+    return int_val

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ enrocrypt==1.1.4
 twine==3.6.0
 py-expression-eval==0.3.14
 pygments>=2.7.4 # not directly required, pinned by Snyk to avoid a vulnerability
+black

--- a/tests/test_py_everything.py
+++ b/tests/test_py_everything.py
@@ -1,16 +1,18 @@
-import sys, unittest # Do not remove or change this statement
-sys.path.append("..") # Do not remove or change this statement
-import py_everything as pye # Do not remove or change this statement
-import py_everything.automation as pyeAuto # Do not remove or change this statement
-import py_everything.dateUtils as pyeDate # Do not remove or change this statement
-import py_everything.fileIO as pyeFileIO # Do not remove or change this statement
-import py_everything.maths as pyeMaths # Do not remove or change this statement
-import py_everything.error as pyeError # Do not remove or change this statement
-import py_everything.search as pyeSearch # Do not remove or change this statement
-import py_everything.web as pyeWeb # Do not remove or change this statement
-import py_everything.htmlXml as pyeHtml # Do not remove or change this statement
-import py_everything.mensuration as pyeMensuration # Do not remove or change this statement
-import py_everything.conversion as pyeConversion # Do not remove or change this statement
+import sys, unittest  # Do not remove or change this statement
+
+sys.path.append("..")  # Do not remove or change this statement
+import py_everything as pye  # Do not remove or change this statement
+import py_everything.automation as pyeAuto  # Do not remove or change this statement
+import py_everything.dateUtils as pyeDate  # Do not remove or change this statement
+import py_everything.fileIO as pyeFileIO  # Do not remove or change this statement
+import py_everything.maths as pyeMaths  # Do not remove or change this statement
+import py_everything.error as pyeError  # Do not remove or change this statement
+import py_everything.search as pyeSearch  # Do not remove or change this statement
+import py_everything.web as pyeWeb  # Do not remove or change this statement
+import py_everything.htmlXml as pyeHtml  # Do not remove or change this statement
+import py_everything.mensuration as pyeMensuration  # Do not remove or change this statement
+import py_everything.conversion as pyeConversion  # Do not remove or change this statement
+import py_everything.roman as pyeRoman  # Do not remove or change this statement
 
 # Do not change the filename.
 # Do not change the folder name.
@@ -20,7 +22,7 @@ import py_everything.conversion as pyeConversion # Do not remove or change this 
 # class TestPyEverything(unittest.TestCase):
 #     def test_[function_name]():
 #         code to test goes here
-#         example given below - 
+#         example given below -
 #         assert py_everything.maths.add(2, 4) == 6
 
 
@@ -56,7 +58,7 @@ class TestPyEverything(unittest.TestCase):
         assert pyeMaths.avg([2, 4, 6, 8]) == 5
 
     def test_read_file(self):
-        assert pyeFileIO.readFile("read.txt") == 'demo\n'
+        assert pyeFileIO.readFile("read.txt") == "demo\n"
 
     def test_write_file(self):
         assert pyeFileIO.writeFile("write.txt", "demo data") is True
@@ -65,35 +67,105 @@ class TestPyEverything(unittest.TestCase):
         assert pyeFileIO.clearFile("clear.txt") is True
 
     def test_search_list(self):
-        listToTest = ["py", "pypi", "anything", "something", "python", "other", "middlepy", "notmatch", "endpy"]
-        assert pyeSearch.searchList(listToTest, "py") == ["py", "pypi", "python", "middlepy", "endpy"]
+        listToTest = [
+            "py",
+            "pypi",
+            "anything",
+            "something",
+            "python",
+            "other",
+            "middlepy",
+            "notmatch",
+            "endpy",
+        ]
+        assert pyeSearch.searchList(listToTest, "py") == [
+            "py",
+            "pypi",
+            "python",
+            "middlepy",
+            "endpy",
+        ]
 
     def test_search_list_2(self):
-        listToTest = ["py", "pypi", "anything", "something", "python", "other", "middlepy", "notmatch", "endpy"]
-        assert pyeSearch.searchList(listToTest, "py", filter="start") == ["py", "pypi", "python"]
+        listToTest = [
+            "py",
+            "pypi",
+            "anything",
+            "something",
+            "python",
+            "other",
+            "middlepy",
+            "notmatch",
+            "endpy",
+        ]
+        assert pyeSearch.searchList(listToTest, "py", filter="start") == [
+            "py",
+            "pypi",
+            "python",
+        ]
 
     def test_search_list_3(self):
-        listToTest = ["py", "pypi", "anything", "something", "python", "other", "middlepy", "notmatch", "endpy"]
-        assert pyeSearch.searchList(listToTest, "py", filter="end") == ["py", "middlepy", "endpy"]
+        listToTest = [
+            "py",
+            "pypi",
+            "anything",
+            "something",
+            "python",
+            "other",
+            "middlepy",
+            "notmatch",
+            "endpy",
+        ]
+        assert pyeSearch.searchList(listToTest, "py", filter="end") == [
+            "py",
+            "middlepy",
+            "endpy",
+        ]
 
     def test_search_list_4(self):
-        listToTest = ["py", "pypi", "anything", "something", "python", "other", "middlepy", "notmatch", "endpy"]
+        listToTest = [
+            "py",
+            "pypi",
+            "anything",
+            "something",
+            "python",
+            "other",
+            "middlepy",
+            "notmatch",
+            "endpy",
+        ]
         assert pyeSearch.searchList(listToTest, "py", filter="exact") == ["py"]
-        
-    def test_get_elements_by_id(self):
-        assert pyeHtml.getElementsById("app", "index.html") == [(10, '<div id="app">something</div>'), (10, '<div id="app">something</div>'), (20, '<div id=\'app\' class="app">something</div>')]
-        
-    def test_get_elements_by_class(self):
-        assert pyeHtml.getElementsByClass("app", "index.html") == [(16, "<p class='app'>something</p>"), (20, '<div id=\'app\' class="app">something</div>'), (25, "<div class='app'>something</div>")]
-        
-    def test_get_element_by_tag(self):
-        assert pyeHtml.getElementByTag("p", "index.html") == [(11, '<p>something</p>')]
-        
-    def test_get_element_by_id(self):
-        assert pyeHtml.getElementById("app", "index.html") == [(10, '<div id="app">something</div>')]
-        
-    def test_get_element_by_class(self):
-        assert pyeHtml.getElementByClass("app", "index.html") == [(16, "<p class='app'>something</p>")]
 
-if __name__ == '__main__':
+    def test_get_elements_by_id(self):
+        assert pyeHtml.getElementsById("app", "index.html") == [
+            (10, '<div id="app">something</div>'),
+            (10, '<div id="app">something</div>'),
+            (20, "<div id='app' class=\"app\">something</div>"),
+        ]
+
+    def test_get_elements_by_class(self):
+        assert pyeHtml.getElementsByClass("app", "index.html") == [
+            (16, "<p class='app'>something</p>"),
+            (20, "<div id='app' class=\"app\">something</div>"),
+            (25, "<div class='app'>something</div>"),
+        ]
+
+    def test_get_element_by_tag(self):
+        assert pyeHtml.getElementByTag("p", "index.html") == [(11, "<p>something</p>")]
+
+    def test_get_element_by_id(self):
+        assert pyeHtml.getElementById("app", "index.html") == [
+            (10, '<div id="app">something</div>')
+        ]
+
+    def test_get_element_by_class(self):
+        assert pyeHtml.getElementByClass("app", "index.html") == [
+            (16, "<p class='app'>something</p>")
+        ]
+
+    def test_convert_roman(self):
+        assert pyeRoman.convertRoman("MMXXI") == 2021
+
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This creates a python function that converts any roman numeral to its integer equivalent. 

Function - convertRoman()

Example:
```
>>> print (convertRoman('MMXXI'))
2021
```

Closes issue #85 

Modified:
- Added black library for text formatting to requirements file
- Updated the gitignore file to ignore virtual environments
- Created the function and test case
